### PR TITLE
Use uuid.Must for making UUIDs

### DIFF
--- a/migrate/migrations.go
+++ b/migrate/migrations.go
@@ -48,7 +48,7 @@ func migrateToV2(ctx infra.DnoteCtx) error {
 		notes := []migrateToV2PostNote{}
 		for _, note := range book {
 			newNote := migrateToV2PostNote{
-				UUID:     uuid.NewV4().String(),
+				UUID:     uuid.Must(uuid.NewV4()).String(),
 				Content:  note.Content,
 				AddedOn:  note.AddedOn,
 				EditedOn: 0,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,7 +24,7 @@ func init() {
 
 // GenerateUID returns a uid
 func GenerateUID() string {
-	return uuid.NewV4().String()
+	return uuid.Must(uuid.NewV4()).String()
 }
 
 func GetInput() (string, error) {


### PR DESCRIPTION
The UUID library changed its API (see [this issue](https://github.com/satori/go.uuid/issues/66)), and it looks unlikely the change will be reverted. Whether you think it's better to pin the dependency to the revision prior to the change, or change the usage in the code is up to you.

Here's what a 'go build' looks like prior to the change:
> shell@host$ go build
> github.com/dnote-io/cli/utils
> utils/utils.go:27:19: multiple-value uuid.NewV4() in single-value context

After code changes, the tests pass. 

> shell@host$ go test
> PASS
> ok  	github.com/dnote-io/cli	1.150s