### PR TITLE
Fix windows console colours, include installer script for windows

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/fatih/color"
+  packages = ["."]
+  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
+  version = "v1.6.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
@@ -18,6 +24,18 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -44,6 +62,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -52,6 +76,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a6df84725e42f485baf9261b9d48ad577c4687d5d7f5b90353d1e40606f40e26"
+  inputs-digest = "78f6d9536359b04aae8697ac22a2f0284223dea0c28a3c5287122dca041e0ef6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -1,7 +1,6 @@
 package ls
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/dnote-io/cli/core"
@@ -89,7 +88,8 @@ func printBooks(dnote infra.Dnote) error {
 	})
 
 	for _, info := range infos {
-		log.Printf("%s \033[%dm(%d)\033[0m\n", info.BookName, log.ColorYellow, info.NoteCount)
+		//log.Printf("%s \033[%dm(%d)\033[0m\n", info.BookName, log.ColorYellow, info.NoteCount)
+		log.Printf("%s %s\n", info.BookName, log.SprintfYellow("(%d)", info.NoteCount))
 	}
 
 	return nil
@@ -101,7 +101,7 @@ func printNotes(dnote infra.Dnote, bookName string) error {
 	book := dnote[bookName]
 
 	for i, note := range book.Notes {
-		fmt.Printf("  \033[%dm(%d)\033[0m %s\n", log.ColorYellow, i, note.Content)
+		log.Plainf("%s %s\n", log.SprintfYellow("(%d)", i), note.Content)
 	}
 
 	return nil

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -88,7 +88,6 @@ func printBooks(dnote infra.Dnote) error {
 	})
 
 	for _, info := range infos {
-		//log.Printf("%s \033[%dm(%d)\033[0m\n", info.BookName, log.ColorYellow, info.NoteCount)
 		log.Printf("%s %s\n", info.BookName, log.SprintfYellow("(%d)", info.NoteCount))
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"fmt"
+
+	"github.com/fatih/color"
 )
 
 var (
@@ -12,22 +14,29 @@ var (
 	ColorGray   = 37
 )
 
+var (
+	SprintfGreen  = color.New(color.FgGreen).SprintfFunc()
+	SprintfYellow = color.New(color.FgYellow).SprintfFunc()
+	SprintfBlue   = color.New(color.FgBlue).SprintfFunc()
+	SprintfGray   = color.New(color.FgWhite).SprintfFunc()
+)
+
 var indent = "  "
 
 func Info(msg string) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s\n", indent, ColorBlue, "•", msg)
+	fmt.Fprintf(color.Output, "%s %s %s\n", indent, SprintfBlue("•"), msg)
 }
 
 func Infof(msg string, v ...interface{}) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s", indent, ColorBlue, "•", fmt.Sprintf(msg, v...))
+	fmt.Fprintf(color.Output, "%s %s %s", indent, SprintfBlue("•"), fmt.Sprintf(msg, v...))
 }
 
 func Success(msg string) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s", indent, ColorGreen, "✔", msg)
+	fmt.Fprintf(color.Output, "%s%s %s", indent, SprintfGreen("✔"), msg)
 }
 
 func Successf(msg string, v ...interface{}) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s", indent, ColorGreen, "✔", fmt.Sprintf(msg, v...))
+	fmt.Fprintf(color.Output, "%s%s %s", indent, SprintfGreen("✔"), fmt.Sprintf(msg, v...))
 }
 
 func Plain(msg string) {
@@ -35,7 +44,7 @@ func Plain(msg string) {
 }
 
 func Plainf(msg string, v ...interface{}) {
-	fmt.Printf("%s%s", indent, fmt.Sprintf(msg, v...))
+	fmt.Fprintf(color.Output, "%s%s", indent, fmt.Sprintf(msg, v...))
 }
 
 func Warnf(msg string, v ...interface{}) {
@@ -47,7 +56,7 @@ func Error(msg string) {
 }
 
 func Printf(msg string, v ...interface{}) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s", indent, ColorGray, "•", fmt.Sprintf(msg, v...))
+	fmt.Fprintf(color.Output, "%s%s %s", indent, SprintfGray("•"), fmt.Sprintf(msg, v...))
 }
 
 func WithPrefixf(prefixColor int, prefix, msg string, v ...interface{}) {

--- a/log/log.go
+++ b/log/log.go
@@ -7,14 +7,7 @@ import (
 )
 
 var (
-	ColorRed    = 31
-	ColorGreen  = 32
-	ColorYellow = 33
-	ColorBlue   = 34
-	ColorGray   = 37
-)
-
-var (
+	SprintfRed    = color.New(color.FgRed).SprintfFunc()
 	SprintfGreen  = color.New(color.FgGreen).SprintfFunc()
 	SprintfYellow = color.New(color.FgYellow).SprintfFunc()
 	SprintfBlue   = color.New(color.FgBlue).SprintfFunc()
@@ -48,17 +41,13 @@ func Plainf(msg string, v ...interface{}) {
 }
 
 func Warnf(msg string, v ...interface{}) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s", indent, ColorRed, "•", fmt.Sprintf(msg, v...))
+	fmt.Fprintf(color.Output, "%s%s %s", indent, SprintfRed("•"), fmt.Sprintf(msg, v...))
 }
 
 func Error(msg string) {
-	fmt.Printf("%s\033[%dm%s\033[0m %s\n", indent, ColorRed, "⨯", msg)
+	fmt.Fprintf(color.Output, "%s%s %s\n", indent, SprintfRed("⨯"), msg)
 }
 
 func Printf(msg string, v ...interface{}) {
 	fmt.Fprintf(color.Output, "%s%s %s", indent, SprintfGray("•"), fmt.Sprintf(msg, v...))
-}
-
-func WithPrefixf(prefixColor int, prefix, msg string, v ...interface{}) {
-	fmt.Printf("  \033[%dm%s\033[0m %s\n", prefixColor, prefix, fmt.Sprintf(msg, v...))
 }

--- a/windows-install.bat
+++ b/windows-install.bat
@@ -1,0 +1,37 @@
+@echo off
+set DNOTEPATH=%PROGRAMFILES%\Dnote CLI
+set DNOTEDL=dnote-windows-amd64.exe
+set DNOTETARGET=%DNOTEPATH%\dnote.exe
+echo Checking for directory...
+if not exist "%DNOTEPATH%\" (
+  echo Creating directory...
+  mkdir "%DNOTEPATH%"
+)
+echo Moving program to target directory...
+move /Y %DNOTEDL% "%DNOTETARGET%"
+echo "Adding directory to user PATH..."
+
+REM retrieve only the user's PATH from registry,
+REM to avoid attempting (and probably failing) to overwrite the
+REM system path
+
+set Key=HKCU\Environment
+FOR /F "tokens=2* skip=1" %%G IN ('REG QUERY %Key% /v PATH') DO (
+  echo %%H > user_path_backup.txt
+  set t=%%H
+  set "NEWPATH="
+  :loop
+  for /f "delims=; tokens=1*" %%a in ("%t%") do (
+    set t=%%b
+    if not "%%a" == "%DNOTEPATH%" (
+      if defined NEWPATH (
+        set NEWPATH=%NEWPATH%;%%a
+      ) else (
+        set NEWPATH=%%a
+      )
+    )
+  )
+  if defined t goto :loop
+)
+set NEWPATH=%NEWPATH%;%DNOTEPATH%
+setx PATH "%NEWPATH%"


### PR DESCRIPTION
Fix for #59 by replacing direct ANSI escape code injection with [fatih/color](https://github.com/fatih/color) library.

Also added a batch script for windows installs: .exe is renamed and moved to a directory which is then added to the user's execution PATH. It is required that the script is in the same directory as the downloaded binary when it is run, so I would suggest placing both in a zip file together.
