### PR TITLE
Add support for neovim editor

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -88,6 +88,8 @@ func getEditorCommand() string {
 		return "mate -w"
 	case "vim":
 		return "vim"
+	case "nvim":
+		return "nvim"
 	case "nano":
 		return "nano"
 	case "emacs":


### PR DESCRIPTION
dnote.io client seems to ignore neovim as an editor (`EDITOR="nvim"`) and instead runs vi which is a default option. In my case this leads to errors as I have some settings in `.vimrc` file which are not recognized by vi. 
I have created a minimal untested PR - I don't code in golang and after few failed attempts to run the code locally I gave up :-) but it seems like you don't to anything specific with editors so this should be enough.
The other, better solution would be probably using `"vi"` as default editor value only of `EDITOR` environment variable is unset and in all other unrecognized editors - and also all other editors which don't need any special flags - you would simply keep using the actual `EDITOR` value.
I am happy to change the PR to your liking.
