### PR TITLE
Multiline support

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,12 +4,14 @@
 * [edit](#dnote-edit)
 * [remove](#dnote-remove)
 * [ls](#dnote-ls)
+* [cat](#dnote-cat)
 * [upgrade](#dnote-upgrade)
 * [login](#dnote-login)
 * [sync](#dnote-sync)
 
 ## dnote add
-*alias: a, n, new*
+
+_alias: a, n, new_
 
 Add a new note to a book.
 
@@ -21,14 +23,13 @@ Launch a text editor to add a new note to the specified book.
 
 Write a new note with a content to the specified book.
 
-
 e.g.
 
     $ dnote add linux -c "find - recursively walk the directory"
 
-
 ## dnote edit
-*alias: e*
+
+_alias: e_
 
 Edit a note
 
@@ -45,7 +46,8 @@ e.g
     $ dnote edit linux 1 "New Content"
 
 ## dnote remove
-*alias: d*
+
+_alias: d_
 
 Remove either a note or a book
 
@@ -62,9 +64,9 @@ e.g
     $ dnote remove JS 1
     $ dnote remove -b JS
 
-
 ## dnote ls
-*alias: l, notes*
+
+_alias: l, notes_
 
 List books or notes
 
@@ -77,20 +79,34 @@ List all books.
 List all notes in the book.
 
 e.g
+
     $ dnote ls
     $ dnote ls golang
 
+## dnote cat
+
+_alias: c_
+
+See details of a note
+
+### `dnote cat [book name] [note index]`
+
+e.g
+
+    $ dnote cat golang 12
 
 ## dnote upgrade
 
 Upgrade the Dnote if newer release is available
 
 ## dnote sync
-*Dnote Cloud only*
+
+_Dnote Cloud only_
 
 Sync notes with Dnote cloud
 
 ## dnote login
-*Dnote Cloud only*
+
+_Dnote Cloud only_
 
 Start a login prompt

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -1,0 +1,70 @@
+package cat
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/dnote-io/cli/core"
+	"github.com/dnote-io/cli/infra"
+	"github.com/dnote-io/cli/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var example = `
+ * See the notes with index 2 from a book 'javascript'
+ dnote cat javascript 2
+ `
+
+func preRun(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return errors.New("Incorrect number of arguments")
+	}
+
+	return nil
+}
+
+func NewCmd(ctx infra.DnoteCtx) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "cat <book name> <note index>",
+		Aliases: []string{"c"},
+		Short:   "See a note",
+		Example: example,
+		RunE:    newRun(ctx),
+		PreRunE: preRun,
+	}
+
+	return cmd
+}
+
+func newRun(ctx infra.DnoteCtx) core.RunEFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		dnote, err := core.GetDnote(ctx)
+		if err != nil {
+			return errors.Wrap(err, "reading dnote")
+		}
+
+		bookName := args[0]
+		noteIdx, err := strconv.Atoi(args[1])
+		if err != nil {
+			return errors.Wrapf(err, "parsing note index '%+v'", args[1])
+		}
+
+		book := dnote[bookName]
+		note := book.Notes[noteIdx]
+
+		log.Plain("\n")
+		log.Infof("book name: %s\n", bookName)
+		log.Infof("note uuid: %s\n", note.UUID)
+		log.Infof("created at: %s\n", time.Unix(note.AddedOn, 0).Format("Jan 2, 2006 3:04pm (MST)"))
+		if note.EditedOn != 0 {
+			log.Infof("updated at: %s\n", time.Unix(note.EditedOn, 0).Format("Jan 2, 2006 3:04pm (MST)"))
+		}
+		fmt.Printf("\n------------------------content------------------------\n")
+		fmt.Printf("%s", note.Content)
+		fmt.Printf("\n-------------------------------------------------------\n")
+
+		return nil
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -492,9 +492,7 @@ func FilterNotes(notes []infra.Note, testFunc func(infra.Note) bool) []infra.Not
 func SanitizeContent(s string) string {
 	var ret string
 
-	ret = strings.Replace(s, "\n", "", -1)
-	ret = strings.Replace(ret, "\r\n", "", -1)
-	ret = strings.Trim(ret, " ")
+	ret = strings.Trim(s, " ")
 
 	return ret
 }

--- a/core/core.go
+++ b/core/core.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// Version is the current version of dnote
-	Version = "0.2.2"
+	Version = "0.3.0"
 
 	// TimestampFilename is the name of the file containing upgrade info
 	TimestampFilename = "timestamps"

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	// commands
 	"github.com/dnote-io/cli/cmd/add"
+	"github.com/dnote-io/cli/cmd/cat"
 	"github.com/dnote-io/cli/cmd/edit"
 	"github.com/dnote-io/cli/cmd/login"
 	"github.com/dnote-io/cli/cmd/ls"
@@ -44,6 +45,7 @@ func main() {
 	root.Register(sync.NewCmd(ctx))
 	root.Register(version.NewCmd(ctx))
 	root.Register(upgrade.NewCmd(ctx))
+	root.Register(cat.NewCmd(ctx))
 
 	if err := root.Execute(); err != nil {
 		log.Errorf("%s\n", err.Error())


### PR DESCRIPTION
* Allow to add notes with linebreaks.
* `dnote ls` shows only the first line and collapses the rest of content with `[--more--]`.
* `dnote cat <book name> <note index>` to see the details of the a note including its full content.